### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.kpat.json
+++ b/org.kde.kpat.json
@@ -13,6 +13,15 @@
         "--socket=pulseaudio",
         "--socket=wayland"
     ],
+    "cleanup": [
+        "/include",
+        "/lib/cmake",
+        "/lib/pkgconfig",
+        "/man/",
+        "/share/doc",
+        "/share/man",
+        "/share/qlogging-categories6"
+    ],
     "modules": [
         {
             "name": "libkdegames",


### PR DESCRIPTION
KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.